### PR TITLE
switched websocket msg to matrix

### DIFF
--- a/headset-sim/src/createMatrix.rs
+++ b/headset-sim/src/createMatrix.rs
@@ -1,0 +1,30 @@
+use serde_json::{json, Value};
+use rand::Rng;
+use std::error::Error;
+
+// Generate a random matrix and return it as a JSON string
+pub fn generate_random_matrix() -> String {
+    let rows = 20;
+    let cols = 5;
+
+    let mut rng = rand::thread_rng();
+    let mut data = Vec::new();
+    for _ in 0..rows {
+        let mut row = Vec::new();
+        for _ in 0..cols {
+            row.push(rng.gen::<i32>()); 
+        }
+        data.push(row);
+    }
+
+    let result = json!({
+        "metadata": {
+            "size": format!("{}x{}", rows, cols)
+        },
+        "data": data
+    });
+
+    let result_string = serde_json::to_string(&result).unwrap();
+
+    return result_string;
+}

--- a/headset-sim/src/main.rs
+++ b/headset-sim/src/main.rs
@@ -3,17 +3,20 @@ use std::net::TcpListener;
 use std::thread::spawn;
 use tungstenite::accept;
 use serde_json::to_string;
+mod createMatrix;
+use createMatrix::generate_random_matrix;
 
 /// WebSocket server
 fn main () {
+    // let random_matrix = generate_random_matrix();
     let server = TcpListener::bind("127.0.0.1:9001").unwrap();
     for stream in server.incoming() {
-        spawn (move || {
+        let randomMtrx = generate_random_matrix();
+        println!("{:?}", randomMtrx);
+        spawn(move || {
             let mut websocket = accept(stream.unwrap()).unwrap();
             loop {
-                let random_numbers: Vec<i32> = (0..64).map(|_| rand::thread_rng().gen_range(1..101)).collect();
-                let serialized_numbers = to_string(&random_numbers).unwrap();
-                websocket.send(tungstenite::Message::Text(serialized_numbers)).unwrap();
+                websocket.send(tungstenite::Message::Text(randomMtrx.clone())).unwrap();
                 std::thread::sleep(std::time::Duration::from_secs(1));
             }
         });


### PR DESCRIPTION
### Changes Being Made

Purpose of Change:

- [x] New feature
- [ ] Revision of current feature
- [ ] Fixing current feature
- [ ] Other: _______________________

Here give examples of the changes you've made in this pull request. Include an itemized list if you can.

- Add examples here...
-  CreateMatrix function returns a JSON format string matrix containing random integers as well as metadata.
- Changed the WebSocket message sent from an array to a matrix.

### How to Test?
cargo run
Open Postman and connect it to the URL ws://127.0.0.1:9001. Each connection will receive a different matrix, the matrix will be resent every second until connection is interrupted. 

(Describe the prerequisites and the steps to test)

### Screenshots (optional)

### Other Notes
